### PR TITLE
fix for mac arm64 and windows installation

### DIFF
--- a/graphviz.ijs
+++ b/graphviz.ijs
@@ -258,7 +258,13 @@ else.
   ferase fname
   PROG=: selitem prog
   y fwrite tf
-  if. UNAME-:'Darwin' do. PROG=: '/usr/local/bin/',PROG end.
+  if. UNAME-:'Darwin' do.
+    if. (9!:56'cpu')-:'arm64' do.
+      PROG=: '/opt/homebrew/bin/',PROG
+    else.
+      PROG=: '/usr/local/bin/',PROG
+    end.
+  end.
   spawn_jtask_,PROG,' ',cmdline
   out=. fread tf,'.out'
   ferase tf
@@ -273,7 +279,12 @@ navigate 'file:///',fname
 )
 gvlocate=: 3 : 0
 if. IFWIN do. OLDDIR=: jpath '~addons/graphics/graphviz'
-elseif. UNAME-:'Darwin' do. OLDDIR=:'/usr/local/share/graphviz/graphs'
+elseif. UNAME-:'Darwin' do.
+  if. (9!:56'cpu')-:'arm64' do.
+    OLDDIR=:'/opt/homebrew/share/graphviz/graphs'
+  else.
+    OLDDIR=:'/usr/local/share/graphviz/graphs'
+  end.
 elseif. +/'Ubuntu' E. spawn_jtask_'uname -a' do. OLDDIR=: '/usr/share/doc/graphviz/examples/graphs'
 elseif. +/'CentOS' E. spawn_jtask_'lsb_release -a' do. OLDDIR=: '/usr/share/graphviz/graphs'
 elseif. 1 do. OLDDIR=: jpath '~addons/graphics/graphviz'
@@ -328,7 +339,6 @@ if. fail +. 0 >: fsize to do.
   return.
 end.
 ferase lg
-mkdir_j_ tgt
 shellcmd_jpacman_ UNZIP_jpacman_,to,' -d ',temp
 dircopy_jpacman_ (temp,'/release/bin');jpath '~addons/graphics/graphviz/bin'
 dircopy_jpacman_ (temp,'/release/fonts');jpath '~addons/graphics/graphviz/fonts'

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -15,7 +15,7 @@ Copyright 2006 (C) Oleg Kobchenko
 
 FOLDER=: 'graphics/graphviz'
 
-VERSION=: '2.0.12'
+VERSION=: '2.0.13'
 
 RELEASE=: ''
 

--- a/source/win.ijs
+++ b/source/win.ijs
@@ -212,7 +212,12 @@ navigate 'file:///',fname
 NB. =========================================================
 gvlocate=: 3 : 0
 if. IFWIN do. OLDDIR=: jpath '~addons/graphics/graphviz'
-elseif. UNAME-:'Darwin' do. OLDDIR=:'/usr/local/share/graphviz'
+elseif. UNAME-:'Darwin' do.
+  if. (9!:56'cpu')-:'arm64' do.
+    OLDDIR=:'/opt/homebrew/share/graphviz/graphs'
+  else.
+    OLDDIR=:'/usr/local/share/graphviz/graphs'
+  end.
 elseif. +/'Ubuntu' E. spawn_jtask_'uname -a' do. OLDDIR=: '/usr/share/doc/graphviz/examples/graphs'
 elseif. +/'CentOS' E. spawn_jtask_'lsb_release -a' do. OLDDIR=: '/usr/share/graphviz/graphs'
 elseif. 1 do. OLDDIR=: jpath '~addons/graphics/graphviz'
@@ -277,7 +282,6 @@ if. fail +. 0 >: fsize to do.
   return.
 end.
 ferase lg
-mkdir_j_ tgt
 shellcmd_jpacman_ UNZIP_jpacman_,to,' -d ',temp
 dircopy_jpacman_ (temp,'/release/bin');jpath '~addons/graphics/graphviz/bin'
 dircopy_jpacman_ (temp,'/release/fonts');jpath '~addons/graphics/graphviz/fonts'


### PR DESCRIPTION
* Added paths to dot program and example files for mac arm64
* Deleted useless (tgt is undefined) mkdir_j_ tgt
which caused an error when installing on Windows