### PR TITLE
fix design and multiple window usage

### DIFF
--- a/graphviz.ijs
+++ b/graphviz.ijs
@@ -1,7 +1,7 @@
 coclass 'pgraphview'
 
 TITLE=: 'Graph View'
-TEMPFILE=: 'graphview'
+TEMPFILE=: 'graphview_'
 TEMPDIR=: jpath '~temp'
 ADDONDIR=: jpath '~addons/graphics/graphviz'
 FILTER=: IFWIN pick ('Graph File .gv (*.gv)|Graph File .dot (*.dot)|All Files (*.*)');'Graph File (*.gv)|Graph File (*.dot)|All Files (*.*)'
@@ -74,15 +74,16 @@ WD=: 0 : 0
 pc graphviz;
 bin v;
 bin h;
- cc Addr static;cn "Address";
- cc turl edit;
- cc gvmsglab static;cn "Message";
- cc gvmsg edit;
- cc Go button;cn "Go";
-bin z;
-bin h;
- bin h;
-  splith;
+ splitv;
+  cc wv webview;
+  splitsep;
+  bin h;
+   cc Addr static;cn "File ";
+   cc turl edit;
+   cc gvmsglab static;cn " Message "; NB. what is it for?
+   cc gvmsg edit;
+   cc Generate button;cn "Generate ☝︎";
+  bin z;
   cc sels tab;
 
   tabnew Source;
@@ -91,7 +92,7 @@ bin h;
   tabnew Options;
    bin v;
     bin h;
-     cc Prog static;cn "Program";
+     cc Prog static;cn "Program ";
      cc prog combobox;
      cc proghelp button;cn "?";
      bin s;
@@ -105,10 +106,7 @@ bin h;
    bin z;
    bin s;
   tabend;
-
- bin z;
- splitsep;
- cc wv webview;
+  
  splitend;
 bin z;
 bin z;
@@ -153,7 +151,7 @@ wd'menusep'
 wd'menu close "Close"'
 wd'menupopz'
 wd 'menupop "View"'
-wd'menu go "Go" "Ctrl+F5"'
+wd'menu generate "Generate" "Ctrl+F5"'
 wd'menupopz'
 wd 'menupop "Help"'
 wd'menu help "Contents" "Ctrl+F1"'
@@ -162,10 +160,7 @@ wd'menusep'
 wd'menu about "About"'
 wd'menupopz'
 
-wd 'set gvmsg sizepolicy expanding fixed'
-wd 'set sels sizepolicy preferred'
-wd 'set wv sizepolicy expanding'
-wd 'set src wrap 0'
+wd 'set wv minwh 500 500'
 
 astext=: ,'0'
 ndxp=. 'dot' ndx PROGRAMS
@@ -198,15 +193,15 @@ end.
 )
 
 graphviz_clean_button=: 3 : 0
-r=. ":+/0>.ferase fpaths jpath'~temp/graphview.*'
+r=. ":+/0>.ferase fpaths jpath'~temp/graphview_*'
 wdinfo 'Cleaning ...';'Erased ',r,' temporary file(s)'
 )
 
-graphviz_go_button=: 3 : 0
+graphviz_generate_button=: 3 : 0
 show src
 )
 
-graphviz_Go_button=: graphviz_go_button
+graphviz_Generate_button=: graphviz_generate_button
 
 graphviz_about_button=: navigate bind ('file:///',ADDONDIR,'/about.html')
 graphviz_help_button=: navigate bind ('file:///',ADDONDIR,'/help.html')
@@ -246,7 +241,7 @@ wd 'set gvmsg text ""'
 if. 0=#y do. error 'Blank input' return. end.
 FMT=: selitem fmt
 ASTEXT=. ('1'-:{.astext)#'.txt'
-fname=. TEMPDIR,'/',TEMPFILE,'.',FMT,ASTEXT
+fname=. TEMPDIR,'/',TEMPFILE,(": ? 1e6),'.',FMT,ASTEXT
 if. IFWIN do.
   cmdline=. '-T',FMT,' -o',unixpath fname
   ferase fname

--- a/graphviz.ijs
+++ b/graphviz.ijs
@@ -80,7 +80,7 @@ bin h;
   bin h;
    cc Addr static;cn "File ";
    cc turl edit;
-   cc gvmsglab static;cn " Message "; NB. what is it for?
+   cc gvmsglab static;cn " Message ";
    cc gvmsg edit;
    cc Generate button;cn "Generate ☝︎";
   bin z;

--- a/manifest.ijs
+++ b/manifest.ijs
@@ -15,7 +15,7 @@ Copyright 2006 (C) Oleg Kobchenko
 
 FOLDER=: 'graphics/graphviz'
 
-VERSION=: '2.0.13'
+VERSION=: '2.0.14'
 
 RELEASE=: ''
 

--- a/source/init.ijs
+++ b/source/init.ijs
@@ -3,7 +3,7 @@ NB. graphviz
 coclass 'pgraphview'
 
 TITLE=: 'Graph View'
-TEMPFILE=: 'graphview'
+TEMPFILE=: 'graphview_'
 TEMPDIR=: jpath '~temp'
 ADDONDIR=: jpath '~addons/graphics/graphviz'
 FILTER=: IFWIN pick ('Graph File .gv (*.gv)|Graph File .dot (*.dot)|All Files (*.*)');'Graph File (*.gv)|Graph File (*.dot)|All Files (*.*)'

--- a/source/win.ijs
+++ b/source/win.ijs
@@ -10,7 +10,7 @@ bin h;
   bin h;
    cc Addr static;cn "File ";
    cc turl edit;
-   cc gvmsglab static;cn " Message "; NB. what is it for?
+   cc gvmsglab static;cn " Message ";
    cc gvmsg edit;
    cc Generate button;cn "Generate ☝︎";
   bin z;

--- a/source/win.ijs
+++ b/source/win.ijs
@@ -4,15 +4,16 @@ WD=: 0 : 0
 pc graphviz;
 bin v;
 bin h;
- cc Addr static;cn "Address";
- cc turl edit;
- cc gvmsglab static;cn "Message";
- cc gvmsg edit;
- cc Go button;cn "Go";
-bin z;
-bin h;
- bin h;
-  splith;
+ splitv;
+  cc wv webview;
+  splitsep;
+  bin h;
+   cc Addr static;cn "File ";
+   cc turl edit;
+   cc gvmsglab static;cn " Message "; NB. what is it for?
+   cc gvmsg edit;
+   cc Generate button;cn "Generate ☝︎";
+  bin z;
   cc sels tab;
 
   tabnew Source;
@@ -21,7 +22,7 @@ bin h;
   tabnew Options;
    bin v;
     bin h;
-     cc Prog static;cn "Program";
+     cc Prog static;cn "Program ";
      cc prog combobox;
      cc proghelp button;cn "?";
      bin s;
@@ -35,10 +36,7 @@ bin h;
    bin z;
    bin s;
   tabend;
-
- bin z;
- splitsep;
- cc wv webview;
+  
  splitend;
 bin z;
 bin z;
@@ -85,7 +83,7 @@ wd'menusep'
 wd'menu close "Close"'
 wd'menupopz'
 wd 'menupop "View"'
-wd'menu go "Go" "Ctrl+F5"'
+wd'menu generate "Generate" "Ctrl+F5"'
 wd'menupopz'
 wd 'menupop "Help"'
 wd'menu help "Contents" "Ctrl+F1"'
@@ -100,10 +98,7 @@ wd'menusep'
 wd'menu about "About"'
 wd'menupopz'
 
-wd 'set gvmsg sizepolicy expanding fixed'
-wd 'set sels sizepolicy preferred'
-wd 'set wv sizepolicy expanding'
-wd 'set src wrap 0'
+wd 'set wv minwh 500 500'
 
 astext=: ,'0'
 ndxp=. 'dot' ndx PROGRAMS
@@ -136,15 +131,15 @@ end.
 )
 
 graphviz_clean_button=: 3 : 0
-r=. ":+/0>.ferase fpaths jpath'~temp/graphview.*'
+r=. ":+/0>.ferase fpaths jpath'~temp/graphview_*'
 wdinfo 'Cleaning ...';'Erased ',r,' temporary file(s)'
 )
 
-graphviz_go_button=: 3 : 0
+graphviz_generate_button=: 3 : 0
 show src
 )
 
-graphviz_Go_button=: graphviz_go_button
+graphviz_Generate_button=: graphviz_generate_button
 
 graphviz_about_button=: navigate bind ('file:///',ADDONDIR,'/about.html')
 graphviz_help_button=: navigate bind ('file:///',ADDONDIR,'/help.html')
@@ -184,7 +179,7 @@ wd 'set gvmsg text ""'
 if. 0=#y do. error 'Blank input' return. end.
 FMT=: selitem fmt
 ASTEXT=. ('1'-:{.astext)#'.txt'
-fname=. TEMPDIR,'/',TEMPFILE,'.',FMT,ASTEXT
+fname=. TEMPDIR,'/',TEMPFILE,(": ? 1e6),'.',FMT,ASTEXT
 if. IFWIN do.
   cmdline=. '-T',FMT,' -o',unixpath fname
   ferase fname
@@ -196,6 +191,13 @@ else.
   ferase fname
   PROG=: selitem prog
   y fwrite tf
+  if. UNAME-:'Darwin' do.
+    if. (9!:56'cpu')-:'arm64' do.
+      PROG=: '/opt/homebrew/bin/',PROG
+    else.
+      PROG=: '/usr/local/bin/',PROG
+    end.
+  end.
   spawn_jtask_,PROG,' ',cmdline
   out=. fread tf,'.out'
   ferase tf


### PR DESCRIPTION
1. Corrected layout of elements in the window for better visibility of displayed graphs.
2. Corrected issue when several graphviz windows opened. It caused to display the same graph in all windows (user had to press Generate button to reload), because of only one filename being used. Now each file has random suffix in name, so it is solved. All generated files can be removed with File > Clean.
3. Added wrap in code, so full code is visible even when generated without whitespace.
4. Added fragment of code to win.ijs from previous commit (I forgot to put it previously, but I had put it to graphviz.ijs, so it worked).